### PR TITLE
Render guide fix links

### DIFF
--- a/docs/guides/render/README.md
+++ b/docs/guides/render/README.md
@@ -9,7 +9,7 @@ To complete this guide, you need:
 
 To deploy to Render, click the following button and follow the instructions:
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/gitpod-openvscode-server.git)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/gitpod-openvscode-server)
 
 After that, create a name for the service group (for example `OpenVSCode Server`) and click <kbd>Apply</kbd>.
 

--- a/docs/guides/render/README.md
+++ b/docs/guides/render/README.md
@@ -9,7 +9,7 @@ To complete this guide, you need:
 
 To deploy to Render, click the following button and follow the instructions:
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/gitpod-openvscode-server-example.git)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/gitpod-openvscode-server.git)
 
 After that, create a name for the service group (for example `OpenVSCode Server`) and click <kbd>Apply</kbd>.
 

--- a/docs/guides/render/README.md
+++ b/docs/guides/render/README.md
@@ -41,7 +41,7 @@ To complete this guide, you need:
 
 ## Set up provider account
 
-Consult the [OAuth2-Proxy Provider Configuration Documentation](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/), and select at least one provider to use for authenticating users of Open VSCode. Create an OAuth application with your provider of choice. For the Homepage/Base URI, enter a placeholder like `https:openvscode-secure-server.onrender.com`, and for the Callback/Redirect URI, enter a placeholder like `https:openvscode-secure-server.onrender.com/oauth2/callback`. You will update the OAuth2 app with your URIs once your OAuth2-Proxy Server deployment is complete. Save the Client Secret and ID in a secure place like a password manager for later reference.
+Consult the [OAuth2-Proxy Provider Configuration Documentation](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/), and select at least one provider to use for authenticating users of Open VSCode. Create an OAuth application with your provider of choice. For the Homepage/Base URI, enter a placeholder like `https://openvscode-secure-server.onrender.com`, and for the Callback/Redirect URI, enter a placeholder like `https://openvscode-secure-server.onrender.com/oauth2/callback`. You will update the OAuth2 app with your URIs once your OAuth2-Proxy Server deployment is complete. Save the Client Secret and ID in a secure place like a password manager for later reference.
 
 
 ## Set up Open VSCode Server


### PR DESCRIPTION
This PR fixes a broken link in the Deploy to Render button due to repo name change.