### PR TITLE
Terminate the server if the port is not available 

### DIFF
--- a/src/vs/server/node/server.main.ts
+++ b/src/vs/server/node/server.main.ts
@@ -1014,12 +1014,19 @@ export async function main(options: IServerOptions): Promise<void> {
 		} else if (typeof options.port === 'number') {
 			port = options.port;
 		}
+
 		const host = parsedArgs.host || '0.0.0.0';
+		server.on('error', () => {
+			server.close();
+			process.exit(1);
+		});
+
 		server.listen(port, host, () => {
 			const addressInfo = server.address() as net.AddressInfo;
 			const address = addressInfo.address === '0.0.0.0' || addressInfo.address === '127.0.0.1' ? 'localhost' : addressInfo.address;
-			const port = addressInfo.port === 80 ? '' : String(addressInfo.port);
-			logService.info(`Web UI available at http://${address}:${port}`);
+			const formattedPort = addressInfo.port === 80 ? '' : String(addressInfo.port);
+			logService.info(`Web UI available at http://${address}:${formattedPort}`);
 		});
+
 	});
 }


### PR DESCRIPTION
The port starts at `3000` / the value provided by `--port` and if that port is not available, the server increments it by 1 and tries again.

Maybe we should exit the process if the user provides a port manually and it is not available, since if it is provided this way, it signals the user relies on it being the port of choosing. 