### PR TITLE
add option to listen on unix domain socket

### DIFF
--- a/src/vs/server/node/server.main.ts
+++ b/src/vs/server/node/server.main.ts
@@ -1010,6 +1010,11 @@ export async function main(options: IServerOptions): Promise<void> {
 			});
 		});
 
+		server.on('error', () => {
+			server.close();
+			process.exit(1);
+		});
+
 		if (parsedArgs.socket) {
 			server.listen(parsedArgs.socket, () => {
 				logService.info(`Server listening on ${parsedArgs.socket}`);
@@ -1023,10 +1028,6 @@ export async function main(options: IServerOptions): Promise<void> {
 			}
 
 			const host = parsedArgs.host || '0.0.0.0';
-			server.on('error', () => {
-				server.close();
-				process.exit(1);
-			});
 			server.listen(port, host, () => {
 				const addressInfo = server.address() as net.AddressInfo;
 				const address = addressInfo.address === '0.0.0.0' || addressInfo.address === '127.0.0.1' ? 'localhost' : addressInfo.address;


### PR DESCRIPTION
This adds a CLI argument --socket, that takes a path.
The server will bind this path instead of a TCP port.

closes #144

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
