### PR TITLE
docs: fix gcp tutorial link

### DIFF
--- a/guides/gcp-gce/README.md
+++ b/guides/gcp-gce/README.md
@@ -10,4 +10,4 @@ To complete this guide, you need:
 
 This guide is available as an interactive Cloud Shell tutorial. To get started, please click the following button:
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/gitpod-io/openvscode-server&cloudshell_tutorial=docs/guides/gcp-gce/cloud-shell-tutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/gitpod-io/openvscode-server&cloudshell_git_branch=docs&cloudshell_tutorial=guides/gcp-gce/cloud-shell-tutorial.md)


### PR DESCRIPTION
it was not using the docs branch and used the wrong path

## Before

![image](https://user-images.githubusercontent.com/3409958/138457619-89533e74-2ed8-4599-9e3a-3b8e02194a31.png)


## After

![image](https://user-images.githubusercontent.com/3409958/138457670-2fc0fd0e-3dc2-406d-bab7-586231b8f7a3.png)

