### PR TITLE
Don't sanitize `command` URLs in getting started

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -182,6 +182,7 @@ function sanitize(documentContent: string): string {
 				'width', 'height', 'align', 'x-dispatch',
 				'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
 			],
+			ALLOW_UNKNOWN_PROTOCOLS: true,
 		});
 	} finally {
 		dompurify.removeHook('afterSanitizeAttributes');


### PR DESCRIPTION
This simply merges https://github.com/microsoft/vscode/pull/135629 into our repo before upstream. 

This PR fixes https://github.com/gitpod-io/gitpod/issues/6246

## How to test
- Open this PR in Gitpod
- After compilation of the server is done, open port 3000
- Open the Gitpod walkthrough (in the command pallet select `Get Started: Open Walkthrough`)
- Try the links in the last three docs
