### PR TITLE
Whitelist CodeTogether for access to Proposed APIs

### DIFF
--- a/product.json
+++ b/product.json
@@ -33,7 +33,8 @@
 		"ms-vscode.vscode-js-profile-flame",
 		"ms-vscode.vscode-js-profile-table",
 		"ms-vscode.vscode-selfhost-test-provider",
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"genuitecllc.codetogether"
 	],
 	"extensionTips": {
 		"msjsdiag.debugger-for-chrome": "{**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.es6,**/.babelrc}",


### PR DESCRIPTION
This PR fixes #170 and adds `genuitecllc.codetogether` as a whitelisted extension.