### PR TITLE
[gitpod] Add 'User-Agent' to API connection headers

### DIFF
--- a/extensions/gitpod-shared/src/features.ts
+++ b/extensions/gitpod-shared/src/features.ts
@@ -267,7 +267,8 @@ export async function createGitpodExtensionContext(context: vscode.ExtensionCont
 				super(address, protocols, {
 					headers: {
 						'Origin': new URL(gitpodHost).origin,
-						'Authorization': `Bearer ${serverToken}`
+						'Authorization': `Bearer ${serverToken}`,
+						'User-Agent': `${vscode.env.appName}/${vscode.version} ${context.extension.id}/${context.extension.packageJSON.version}`,
 					}
 				});
 			}


### PR DESCRIPTION
This PR adds the 'User-Agent' header to websocket connections to the Gitpod API.
