### PR TITLE
Update sourcedive with file blocks

### DIFF
--- a/sourcedive.snb.md
+++ b/sourcedive.snb.md
@@ -4,9 +4,7 @@ This is a technical deep dive into how OpenVSCode Server turns VS Code into a we
 
 The code snippets in this file correspond to search queries and can be displayed by clicking the blue "Run search" button to the right of each query. For example, here is a snippet that shows off an instance of dependency injection within VS Code:
 
-```sourcegraph
-patterntype:structural repo:^github\.com/gitpod-io/openvscode-server$@5c8a1f file:^src/vs/code/browser/workbench/workbench\.ts create(document.body, {:[1]})
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@5c8a1f/-/blob/src/vs/code/browser/workbench/workbench.ts?L517-531
 
 ## Architectural overview
 
@@ -14,76 +12,58 @@ OpenVSCode Server is a fork of VS Code that extends the editor to be runnable in
 
 Upstream VS Code consists of [layers](https://github.com/microsoft/vscode/wiki/Source-Code-Organization):
 
-* `base`: Provides general utilities and user interface building blocks.
-* `platform`: Defines service injection support and the base services for VS Code.
-* `editor`: The "Monaco" editor is available as a separate downloadable component.
-* `workbench`: Hosts the "Monaco" editor and provides the framework for "viewlets" like the Explorer, Status Bar, or Menu Bar, leveraging Electron to implement the VS Code desktop application.
-* `code`: The entry point to the desktop app that stitches everything together, this includes the Electron main file and the CLI for example.
+- `base`: Provides general utilities and user interface building blocks.
+- `platform`: Defines service injection support and the base services for VS Code.
+- `editor`: The "Monaco" editor is available as a separate downloadable component.
+- `workbench`: Hosts the "Monaco" editor and provides the framework for "viewlets" like the Explorer, Status Bar, or Menu Bar, leveraging Electron to implement the VS Code desktop application.
+- `code`: The entry point to the desktop app that stitches everything together, this includes the Electron main file and the CLI for example.
 
 OpenVSCode Server adds an additional [`server` layer](https://github.com/gitpod-io/openvscode-server/tree/main/src/vs/server). The client side remains largely unchanged, save for the injection of RPC-based handlers for things like filesystem and terminal interactions, in place of local handlers. The `server` layer has 3 main components:
 
-* Web-based workbench
-* Remote server
-* Remote CLI
+- Web-based workbench
+- Remote server
+- Remote CLI
 
 The web-based workbench lives on the client side and is the place where the RPC-based dependencies are injected. VS Code's codebase is modular and makes heavy use of dependency injection, which makes it easier to substitute different implementations. The entrypoint into the web-based workbench is in [workbench.ts](https://sourcegraph.com/github.com/gitpod-io/openvscode-server/-/blob/src/vs/code/browser/workbench/workbench.ts). In that file, the `create` function creates the workbench using dependency injection:
 
-```sourcegraph
-patterntype:structural repo:/gitpod-io/openvscode-server$@5c8a1f fork:yes file:server/browser/workbench/workbench.ts create(document.body, :[2])
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@5c8a1f/-/blob/src/vs/server/browser/workbench/workbench.ts?L469-498
 
 The workbench talks to the remote server via RPC. There are 2 RPC channels:
 
-* The management connection handles filesystem and terminal requests
-* The extension connection creates the remote extension host process and handles extension-related requests
+- The management connection handles filesystem and terminal requests
+- The extension connection creates the remote extension host process and handles extension-related requests
 
 Let's take a look at how those connections are set up on the server side. The main entrypoint into the server lives in [`server.main.ts`](https://sourcegraph.com/github.com/gitpod-io/openvscode-server@5c8a1f/-/blob/src/vs/server/node/server.main.ts?L11):
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@5c8a1f file:^src/vs/server/node/server\.main\.ts export async function main
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@5c8a1f/-/blob/src/vs/server/node/server.main.ts?L328
 
 Of particular note in the `main` function is `channelServer`, which registers different service channels for handling different types of requests received from the client, such as logging, debugging, and filesystem requests.
 
-
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@5c8a1f file:^src/vs/server/node/server\.main\.ts const channelServer = 
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@5c8a1f/-/blob/src/vs/server/node/server.main.ts?L352
 
 These channels then relay the requests to the appropriate service implementations. Lower in the `main` function, a `ServiceCollection` instance is used as a dependency injection container that holds all the concrete implementations of the various service types:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts Const services = new ServiceCollection()
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L612
 
 Then the whole bundle is wrapped by an HTTP server, which is the outermost container that handles requests from the client:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts const server = http.createServer
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L664
 
 Some of the handler endpoints correspond to static resources:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts if (pathname === '/vscode-remote-resource')
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L677
 
 Then there are the endpoints that upgrade a HTTP request to a WebSocket connection:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts server.on('upgrade', 
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L730
 
 The aforementioned management connection and extension connection use these WebSocket connections. The management connection connects `channelServer` with your editor window, including requests for handling terminal and fileystem requests.
 
 On the extension side, there's a special protocol over WebSocket that initiates a handshake to set up the remote extension host process:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts const controlListener = protocol.onControlMessage
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L771
 
 The extension connection will fork the extension host process and connect the user's editor window. Among other things, keystrokes are sent down this connection, as they may be relevant to extensions in use.
-
 
 ## Startup
 
@@ -91,76 +71,51 @@ Now, let's walk through what happens at startup.
 
 On server startup, first we create the channel server and register channels to handle RPC calls and events from the web workbench:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 const channelServer = new IPCServer
-```
-
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L354
 
 Then we create the service collection (effectively the dependency injection container for service implementations, as described earlier) with all services required for the RPC channels:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts services.set(IRawURITransformerFactory, rawURITransformerFactory)
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L613
 
 Then we instantiate these services and start the HTTP server:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts const clients = new Map<string, Client>()
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L662
 
 When a user tries to access the server, the web workbench is served by HTTP listener:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 file:^src/vs/server/node/server\.main\.ts return handleRoot(req, res, devMode ? options.mainDev || 
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L689
 
 The web workbench first loads 3rd party dependencies like xterm:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 xterm': `${window.location.origin} file:workbench-dev.html
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/browser/workbench/workbench-dev.html?L46
 
 ...and then itself:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 require(['vs/server/browser/workbench/workbench'], 
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/browser/workbench/workbench-dev.html?L61
 
 The web workbench uses dependency injection to configure how to establish WebSockets, load static resources, load webviews, and so on:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 create(document.body, { file:src/vs/server/
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/browser/workbench/workbench.ts?L469-498
 
 When the web workbench is created, it opens WebSocket connections to the server:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 if (req.headers['upgrade'] !== 'websocket' || !req.url)
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L731
 
 There is one connection to the RPC channel server to notify about a new client:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 onDidClientConnectEmitter.fire({ protocol, onDidClientDisconnect: onDidClientDisconnectEmitter.event })
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L841
 
-...and another for the extension host process which is running remote extensions: 
+...and another for the extension host process which is running remote extensions:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 const extensionHost = cp.fork(FileAccess.asFileUri
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/server.main.ts?L913
 
 When a user creates a new terminal the management connection is used to call the remote terminal channel:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 return this.createProcess(context.remoteAuthority, args);
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/remote-terminal.ts?L81
 
 ...which delegates to pseudo terminal service:
 
-```sourcegraph
-repo:^github\.com/gitpod-io/openvscode-server$@8b3e975 const persistentTerminalId = await this.ptyService.createProcess
-```
+https://sourcegraph.com/github.com/gitpod-io/openvscode-server@8b3e975/-/blob/src/vs/server/node/remote-terminal.ts?L252
 
 The terminal service then enacts the corresponding action and relays the response back through the request chain covered above.
 


### PR DESCRIPTION
Recently, we added a new type of a block to notebooks, called the file block. It allows you to directly reference a range of code, instead of having to go through a search to display it. The sourcedive is a perfect candidate for a refactoring since it displayed only one result per query.

You can see the new version here: https://sourcegraph.com/github.com/novoselrok/openvscode-server@rn/update-sourcedive-with-file-blocks/-/blob/sourcedive.snb.md