### PR TITLE
Fix product config for insider

### DIFF
--- a/src/vs/gitpod/browser/workbench/workbench.ts
+++ b/src/vs/gitpod/browser/workbench/workbench.ts
@@ -964,10 +964,6 @@ async function doStart(): Promise<IDisposable> {
 		urlCallbackProvider: new LocalStorageURLCallbackProvider(),
 		credentialsProvider,
 		productConfiguration: {
-			nameShort: product.nameShort + (info.ideAlias === 'code-latest' ? ' - Insiders' : ''),
-			nameLong: product.nameLong + (info.ideAlias === 'code-latest' ? ' - Insiders' : ''),
-			version: product.version + (info.ideAlias === 'code-latest' ? '-insider' : ''),
-			quality: (info.ideAlias === 'code-latest' ? 'insider' : 'stable'),
 			linkProtectionTrustedDomains: [
 				...(product.linkProtectionTrustedDomains || []),
 				gitpodDomain


### PR DESCRIPTION
Companion PR of https://github.com/gitpod-io/gitpod/pull/9819

Fixes: https://github.com/gitpod-io/gitpod/issues/9380

## Issue

The editor name is misconfigured and not showing correctly when users are using the Insider version.


| Before | After |
|--------|-------|
|  <img width="568" alt="Screenshot 2022-05-12 at 16 49 03" src="https://user-images.githubusercontent.com/2318450/168103612-d2872059-2736-4db5-bee0-ba0db6ff75a9.png">      |   <img width="554" alt="Screenshot 2022-05-12 at 16 49 13" src="https://user-images.githubusercontent.com/2318450/168103669-4993bd8f-c192-40da-a1c0-1312c3cf6a2b.png">


Note: Ignore the light/dark mode
