### PR TITLE
Add analytic for the language of opened files

### DIFF
--- a/extensions/gitpod-shared/src/analytics.ts
+++ b/extensions/gitpod-shared/src/analytics.ts
@@ -2,39 +2,65 @@
  *  Copyright (c) Gitpod. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-export interface BaseGitpodAnalyticsEventPropeties {
-	sessionId: string
-	workspaceId: string
-	instanceId: string
-	appName: string
-	uiKind: 'web' | 'desktop'
-	devMode: boolean
-	version: string
-	timestamp: number
-}
+import path from 'path';
+import * as vscode from 'vscode';
 
+import { GitpodExtensionContext } from './features';
+
+export interface BaseGitpodAnalyticsEventPropeties {
+	sessionId: string;
+	workspaceId: string;
+	instanceId: string;
+	appName: string;
+	uiKind: 'web' | 'desktop';
+	devMode: boolean;
+	version: string;
+	timestamp: number;
+}
 
 interface GAET<N extends string, P> {
-	eventName: N
-	properties: Omit<P, keyof BaseGitpodAnalyticsEventPropeties>
+	eventName: N;
+	properties: Omit<P, keyof BaseGitpodAnalyticsEventPropeties>;
 }
-
 
 export type GitpodAnalyticsEvent =
 	GAET<'vscode_session', {}> |
 	GAET<'vscode_execute_command_gitpod_open_link', {
-		url: string
+		url: string;
 	}> |
 	GAET<'vscode_execute_command_gitpod_change_vscode_type', {
-		targetUiKind: 'web' | 'desktop',
-		targetQualifier?: 'stable' | 'insiders'
+		targetUiKind: 'web' | 'desktop';
+		targetQualifier?: 'stable' | 'insiders';
 	}> |
 	GAET<'vscode_execute_command_gitpod_workspace', {
-		action: 'share' | 'stop-sharing' | 'stop' | 'snapshot' | 'extend-timeout'
+		action: 'share' | 'stop-sharing' | 'stop' | 'snapshot' | 'extend-timeout';
 	}> |
 	GAET<'vscode_execute_command_gitpod_ports', {
-		action: 'private' | 'public' | 'preview' | 'openBrowser'
+		action: 'private' | 'public' | 'preview' | 'openBrowser';
 	}> |
 	GAET<'vscode_execute_command_gitpod_config', {
-		action: 'remove' | 'add'
+		action: 'remove' | 'add';
+	}> |
+	GAET<'vscode_active_language', {
+		lang: string; ext?: string;
 	}>;
+
+export function registerUsageAnalytics(context: GitpodExtensionContext): void {
+	context.fireAnalyticsEvent({ eventName: 'vscode_session', properties: {} });
+}
+
+const activeLanguages = new Set<String>();
+export function registerActiveLanguageAnalytics(context: GitpodExtensionContext): void {
+	const track = () => {
+		const e = vscode.window.activeTextEditor;
+		if (!e || activeLanguages.has(e.document.languageId)) {
+			return;
+		}
+		const lang = e.document.languageId;
+		activeLanguages.add(lang);
+		const ext = path.extname(e.document.uri.path) || undefined;
+		context.fireAnalyticsEvent({ eventName: 'vscode_active_language', properties: { lang, ext } });
+	};
+	track();
+	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(() => track()));
+}

--- a/extensions/gitpod-shared/src/extension.ts
+++ b/extensions/gitpod-shared/src/extension.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { registerActiveLanguageAnalytics, registerUsageAnalytics } from './analytics';
 import { createGitpodExtensionContext, GitpodExtensionContext, registerDefaultLayout, registerNotifications, registerWorkspaceCommands, registerWorkspaceSharing, registerWorkspaceTimeout } from './features';
 
 export { GitpodExtensionContext, registerTasks, SupervisorConnection, registerIpcHookCli } from './features';
@@ -25,16 +26,13 @@ export async function setupGitpodContext(context: vscode.ExtensionContext): Prom
 	vscode.commands.executeCommand('setContext', 'gitpod.UIKind', vscode.env.uiKind === vscode.UIKind.Web ? 'web' : 'desktop');
 
 	registerUsageAnalytics(gitpodContext);
+	registerActiveLanguageAnalytics(gitpodContext);
 	registerWorkspaceCommands(gitpodContext);
 	registerWorkspaceSharing(gitpodContext);
 	registerWorkspaceTimeout(gitpodContext);
 	registerNotifications(gitpodContext);
 	registerDefaultLayout(gitpodContext);
 	return gitpodContext;
-}
-
-function registerUsageAnalytics(context: GitpodExtensionContext): void {
-	context.fireAnalyticsEvent({ eventName: 'vscode_session', properties: {} });
 }
 
 function logContextInfo(context: GitpodExtensionContext) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #

Related https://github.com/gitpod-io/gitpod/issues/9967

## How to test

- Change default IDE in preview env https://hw-vs-lang.preview.gitpod-dev.com/workspaces to `latest(insiders)` code (check if code about commit is `2e8e6adbde94e4eae45000067f6e92b1f4412c03`
- Open a workspace
- Go to [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger), search with `vscode_active_language`, see track log details

Open workspace with Desktop IDE, see if track works like browser one

#### Cases
- Open `README.md` see track with `lang=markdown` and `ext=md`
- Create `a.ts` see if track with `lang=typescript` and `ext=ts`
- Create another ts file `b.ts`, should no new tracking event for lang `typescript`
- Close all files, reload page, no tracking sent
- ~~Open `a.ts` and `b.json` as current editing file (split editor), reload page, see if track send with `typescript` and `json`~~
- Just found that it will report as `Log` if we select `Output` tab in terminal tabbar

## How to test with Desktop Code

We need to re-install `gitpod-remote` extension

- Run `npx gulp package-gitpod-marketplace-extensions`, to package remote extension
- Download remote vsix to you computer
- Open workspace with Desktop Code in prev env
- Upload vsix to your workspace
- Install vsix with file (you can uninstall prev one to make a confirm

|Image|
|-|
|<img src="https://user-images.githubusercontent.com/20944364/168234028-466033ae-e183-449d-8812-f9f957465d4b.png" width="300" />|

---------------------

💡 file ext like `vue` `svelte` etc vscode not detect them as some language but plaintext. You need to install extensions to support them. search extension with their name and try it.

## TODO
- [x] Add track call event after event name confirm [notion](https://www.notion.so/gitpod/d1c05025dae64f4e8dcd3188f121e270?v=e7e87f95dcac436f86d4ec2698e795a7). [Added](https://www.notion.so/gitpod/vscode_active_language-12a8658ae26a49c6b659ae7ffe369ee4)