### PR TITLE
feat(gulp): generate  dummy github auth extension

### DIFF
--- a/src/vs/server/node/remoteAgentEnvironmentImpl.ts
+++ b/src/vs/server/node/remoteAgentEnvironmentImpl.ts
@@ -356,10 +356,8 @@ export class RemoteAgentEnvironmentChannel implements IServerChannel {
 		return scannedExtensions.map(e => toExtensionDescription(e, false)).filter(ext => {
 			// TODO: remove this once whe decoupled gitpod extensions from gp-code
 			const ignoreExtensions = [
-				'vscode.github-authentication',
 				'gitpod.gitpod-shared',
-				'gitpod.gitpod-remote-ssh',
-				'gitpod.gitpod-desktop'
+				'gitpod.gitpod-remote-ssh'
 			];
 			return !ignoreExtensions.includes(ext.identifier.value.toLowerCase());
 		});


### PR DESCRIPTION
Creates a dummy GitHub Auth extension to unblock the 1.68.0 release