### PR TITLE
Fix ports tunnel not works

### DIFF
--- a/extensions/gitpod-web/src/extension.ts
+++ b/extensions/gitpod-web/src/extension.ts
@@ -452,6 +452,7 @@ export class GitpodWorkspaceTreeDataProvider implements vscode.TreeDataProvider<
 					port.contextValue = (exposed.visibility === PortVisibility.PUBLIC ? 'public-' : 'private-') + port.contextValue;
 				}
 				if (port.tunnel) {
+					port.contextValue = 'tunneled-' + port.contextValue;
 					port.contextValue = (isPortTunnelPublic ? 'network-' : 'host-') + port.contextValue;
 				}
 				if (!accessible && portStatus.getAutoExposure() === PortAutoExposure.FAILED) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/gitpod-io/gitpod/issues/10828

## How to Test

- Open a workspace in prev env https://hw-vs-tunnel.preview.gitpod-dev.com/
- Open Remote Explorer, to see port status
- Download [local-app](https://www.gitpod.io/blog/local-app#installation), rename to `local-app` and `chmod +x local-app`
- Exec command `./local-app --gitpod-host https://hw-vs-tunnel.preview.gitpod-dev.com` to connect to prev env
- Reload workspace, to see changes of port status (eyes icon on hover should appear)
- Click to tunnel port in `0.0.0.0` (on hover `eyes` icons)
- Reload page to see changes of port status
- Open that port in you local network in other devices (like your phone), check if tunnel success

With macOS, you can check you internal IP by, `option+click` on Wi-Fi icon

|Tunnel Success|Internal IP Address|Phone Visiable|
|-|-|-|
|![SCR-20220623-3st](https://user-images.githubusercontent.com/20944364/175114343-9c6341df-43fd-4153-b05a-f343ab8d9a57.png)|![image](https://user-images.githubusercontent.com/20944364/175114113-271b7e39-de71-4b74-9865-9c6456e3e1db.png)|![image](https://user-images.githubusercontent.com/20944364/175114219-a097d21b-c458-4476-9576-ba7267856b98.png)|



