### PR TITLE
[gp-web] Fix the case of `URL`

### DIFF
--- a/extensions/gitpod-web/portsview/src/components/HoverOptions.svelte
+++ b/extensions/gitpod-web/portsview/src/components/HoverOptions.svelte
@@ -13,7 +13,7 @@
 
 	export let alwaysShow = false;
 	export let options: HoverOption[] = [
-		{ icon: "copy", command: "copy", title: "Copy Url" },
+		{ icon: "copy", command: "copy", title: "Copy URL" },
 	];
 
 	const dispatch = createEventDispatcher<{ command: string }>();

--- a/extensions/gitpod-web/portsview/src/porttable/PortLocalAddress.svelte
+++ b/extensions/gitpod-web/portsview/src/porttable/PortLocalAddress.svelte
@@ -12,7 +12,7 @@
 
 	const copyOpt: HoverOption = {
 		icon: "copy",
-		title: "Copy Url",
+		title: "Copy URL",
 		command: "urlCopy",
 	};
 


### PR DESCRIPTION
This is just a fix of `URL`, since it was spelled `Url` in some places. URL is an acronym and therefore should be all caps [[1](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL)].
