### PR TITLE
Add `marketplace.json`

### DIFF
--- a/product.json
+++ b/product.json
@@ -761,7 +761,7 @@
 		"serviceUrl": "https://open-vsx.org/vscode/gallery",
 		"itemUrl": "https://open-vsx.org/vscode/item",
 		"resourceUrlTemplate": "https://open-vsx.org/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}",
-		"controlUrl": "",
+		"controlUrl": "https://ide.gitpod.io/code/marketplace.json",
 		"recommendationsUrl": "",
 		"nlsBaseUrl": "",
 		"publisherUrl": ""


### PR DESCRIPTION
This PR sets the URL for deprecated, malicious and other special extensions in `product.json` with values fit for https://open-vsx.org. It would be great to have it under Eclipse, but for now it's under https://github.com/gitpod-io/gitpod/blob/main/components/ide-proxy/static/code/marketplace.json.

This PR fixes https://github.com/gitpod-io/gitpod/issues/10847.

## How to test

1. Open this PR in Gitpod
2. Wait for the new window of VS Code to open
3. Search for `KnisterPeter.vscode-github` in the extensions tab
4. Make sure there is no install button
