### PR TITLE
Ports view improvement

### DIFF
--- a/extensions/gitpod-web/package.json
+++ b/extensions/gitpod-web/package.json
@@ -415,7 +415,8 @@
       "remote": [
         {
           "id": "gitpod.workspace",
-          "name": "Gitpod Workspace"
+          "name": "Gitpod Workspace",
+          "when": "!gitpod.portsView.visible"
         }
       ],
       "portsView": [
@@ -425,7 +426,6 @@
           "type": "webview",
           "contextualTitle": "",
           "icon": "$(plug)",
-          "visibility": "visible",
           "when": "gitpod.portsView.visible"
         }
       ]
@@ -517,7 +517,7 @@
         {
           "id": "portsView",
           "title": "Ports",
-          "icon": ""
+          "icon": "$(plug)"
         }
       ]
     }

--- a/extensions/gitpod-web/portsview/src/App.svelte
+++ b/extensions/gitpod-web/portsview/src/App.svelte
@@ -11,11 +11,7 @@
 
 	window.addEventListener("message", (event) => {
 		if (event.data.command === "updatePorts") {
-			// TODO: sort with status first, then port number?
-			ports = event.data.ports.sort(
-				(a: GitpodPortObject, b: GitpodPortObject) =>
-					a.status.localPort - b.status.localPort
-			);
+			ports = event.data.ports;
 		}
 	});
 	vscode.postMessage({ command: "queryPortData" });


### PR DESCRIPTION
This PR fixes https://github.com/gitpod-io/gitpod/issues/11154

## Improved things

- [x] Drag and drop portsView to left sidebar, icon missed
- [x] Enable it in setting, but still need to reload window to make it visible
- [x] Should set experiment value default `true` in insider vscode
- [ ] First opening is very slow than previous [Remote Explorer](https://www.gitpod.io/blog/local-app#remote-explorer-ports-view)
- [x] ~~Show `Ports` tab on startup without focus~~ Not going to do it, since `Terminal` needs to be the default selection
- [x] Remove sort by port's number
- [x] Prompt a `Try it out` notification while users are using the previous `Remote Explorer`
- [x] Remove previous `Remote Explorer` once we enabled experimental feature
- [x] ~~CHANGELOG~~ as a part of Epic https://github.com/gitpod-io/gitpod/issues/7537, we will continue this here
- [ ] Close issue https://github.com/gitpod-io/gitpod/issues/7408 after this one finished

## How to Test

- Use preview env https://hw-vs-port.preview.gitpod-dev.com/workspaces and choose `latest code` as IDE
- Open a workspace
- Set vscode settings `gitpod.experimental.portsView.enabled` to `false` (since its default value is `true` in latest code)
- Reload window (not necessary) active `Remote Explorer`
- It should prompt a try it out notification like below, 
- Click ok will make 
    - That setting change to true
    - New `Ports` view will be focused after 2 second
    - Previous `Remote Explorer` will dismiss
- Click on ports on the status bar will focus on the new Ports view (the previous one will be Remote Explorer too)

See also things improved above