### PR TITLE
Hide code show release notes command

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -24,8 +24,8 @@ workbench.registerWorkbenchContribution(SwitchProductQualityContribution, Lifecy
 const actionRegistry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
 
 // Editor
-actionRegistry
-	.registerWorkbenchAction(SyncActionDescriptor.from(ShowCurrentReleaseNotesAction), `${product.nameShort}: Show Release Notes`, product.nameShort);
+// actionRegistry
+// 	.registerWorkbenchAction(SyncActionDescriptor.from(ShowCurrentReleaseNotesAction), `${product.nameShort}: Show Release Notes`, product.nameShort);
 
 actionRegistry
 	.registerWorkbenchAction(SyncActionDescriptor.from(CheckForVSCodeUpdateAction), `${product.nameShort}: Check for Update`, product.nameShort, CONTEXT_UPDATE_STATE.isEqualTo(StateType.Idle));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Disable built-in `Show Release Notes` command

## How to test

- Use `latest code` as IDE in preview env https://hw-vs-debug.preview.gitpod-dev.com/workspaces
- Search command with `release` should only have `Gitpod: Show Release Notes`

|Screenshot|
|-|
|![image](https://user-images.githubusercontent.com/20944364/180203888-9b01c62f-a0be-4a76-ab8a-dd3025a6ec7d.png)|
