### PR TITLE
Add experiments using ConfigCat with PortsView

### DIFF
--- a/extensions/gitpod-shared/src/analytics.ts
+++ b/extensions/gitpod-shared/src/analytics.ts
@@ -38,8 +38,9 @@ export type GitpodAnalyticsEvent =
 		action: 'share' | 'stop-sharing' | 'stop' | 'snapshot' | 'extend-timeout';
 	}> |
 	GAET<'vscode_execute_command_gitpod_ports', {
-		action: 'private' | 'public' | 'preview' | 'openBrowser';
+		action: 'private' | 'public' | 'preview' | 'openBrowser' | 'urlCopy';
 		isWebview?: boolean;
+		userOverride?: string; // 'true' | 'false'
 	}> |
 	GAET<'vscode_execute_command_gitpod_config', {
 		action: 'remove' | 'add';

--- a/extensions/gitpod-web/package.json
+++ b/extensions/gitpod-web/package.json
@@ -562,6 +562,7 @@
   "dependencies": {
     "@gitpod/gitpod-protocol": "main",
     "@gitpod/supervisor-api-grpc": "main",
+    "configcat-node": "^8.0.0",
     "gitpod-shared": "0.0.1",
     "node-fetch": "2.6.7",
     "uuid": "8.1.0",

--- a/extensions/gitpod-web/portsview/src/porttable/PortLocalAddress.svelte
+++ b/extensions/gitpod-web/portsview/src/porttable/PortLocalAddress.svelte
@@ -36,6 +36,12 @@
 	function onHoverCommand(command: string) {
 		dispatch("command", { command: command as PortCommand, port });
 	}
+	function openAddr(e: Event) {
+		e.preventDefault();
+		if (port.status.exposed.url) {
+			dispatch("command", { command: "openBrowser" as PortCommand, port });
+		}
+	}
 </script>
 
 <HoverOptions
@@ -45,7 +51,7 @@
 		onHoverCommand(e.detail);
 	}}
 >
-	<a href={port.status.exposed.url}>{port.status.exposed.url}</a>
+	<a on:click={(e) => { openAddr(e) }} href={port.status.exposed.url}>{port.status.exposed.url}</a>
 </HoverOptions>
 
 <style>

--- a/extensions/gitpod-web/src/experiments.ts
+++ b/extensions/gitpod-web/src/experiments.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitpod. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as configcat from 'configcat-node';
+import * as configcatcommon from 'configcat-common';
+import * as semver from 'semver';
+import Log from 'gitpod-shared/out/common/logger';
+import { URL } from 'url';
+
+const EXPERTIMENTAL_SETTINGS = [
+	'gitpod.experimental.portsView.enabled',
+];
+
+export class ExperimentalSettings {
+	private configcatClient: configcatcommon.IConfigCatClient;
+	private extensionVersion: semver.SemVer;
+
+	constructor(key: string, extensionVersion: string, private logger: Log, gitpodHost: string) {
+		this.configcatClient = configcat.createClientWithLazyLoad(key, {
+			baseUrl: new URL('/configcat', process.env['VSCODE_DEV'] ? 'https://gitpod-staging.com' : gitpodHost).href,
+			logger: {
+				debug(): void { },
+				log(): void { },
+				info(): void { },
+				warn(message: string): void { logger.warn(`ConfigCat: ${message}`); },
+				error(message: string): void { logger.error(`ConfigCat: ${message}`); }
+			},
+			requestTimeoutMs: 1500,
+			cacheTimeToLiveSeconds: 60
+		});
+		this.extensionVersion = new semver.SemVer(extensionVersion);
+	}
+
+	async get<T>(key: string, userId?: string, custom?: { [key: string]: string }): Promise<T | undefined> {
+		const config = vscode.workspace.getConfiguration('gitpod');
+		const values = config.inspect<T>(key.substring('gitpod.'.length));
+		if (!values || !EXPERTIMENTAL_SETTINGS.includes(key)) {
+			this.logger.error(`Cannot get invalid experimental setting '${key}'`);
+			return values?.globalValue ?? values?.defaultValue;
+		}
+		if (this.isPreRelease()) {
+			// PreRelease versions always have experiments enabled by default
+			return values.globalValue ?? values.defaultValue;
+		}
+		if (values.globalValue !== undefined) {
+			// User setting have priority over configcat so return early
+			return values.globalValue;
+		}
+
+		const user = userId ? new configcatcommon.User(userId, undefined, undefined, custom) : undefined;
+		const configcatKey = key.replace(/\./g, '_'); // '.' are not allowed in configcat
+		const experimentValue = (await this.configcatClient.getValueAsync(configcatKey, undefined, user)) as T | undefined;
+
+		return experimentValue ?? values.defaultValue;
+	}
+
+	async inspect<T>(key: string, userId?: string, custom?: { [key: string]: string }): Promise<{ key: string; defaultValue?: T; globalValue?: T; experimentValue?: T } | undefined> {
+		const config = vscode.workspace.getConfiguration('gitpod');
+		const values = config.inspect<T>(key.substring('gitpod.'.length));
+		if (!values || !EXPERTIMENTAL_SETTINGS.includes(key)) {
+			this.logger.error(`Cannot inspect invalid experimental setting '${key}'`);
+			return values;
+		}
+
+		const user = userId ? new configcatcommon.User(userId, undefined, undefined, custom) : undefined;
+		const configcatKey = key.replace(/\./g, '_'); // '.' are not allowed in configcat
+		const experimentValue = (await this.configcatClient.getValueAsync(configcatKey, undefined, user)) as T | undefined;
+
+		return { key, defaultValue: values.defaultValue, globalValue: values.globalValue, experimentValue };
+	}
+
+	forceRefreshAsync(): Promise<void> {
+		return this.configcatClient.forceRefreshAsync();
+	}
+
+	private isPreRelease() {
+		return this.extensionVersion.minor % 2 === 1;
+	}
+
+	dispose(): void {
+		this.configcatClient.dispose();
+	}
+}
+
+export function isUserOverrideSetting(key: string): boolean {
+	const config = vscode.workspace.getConfiguration('gitpod');
+	const values = config.inspect(key.substring('gitpod.'.length));
+	return values?.globalValue !== undefined;
+}

--- a/extensions/gitpod-web/src/extension.ts
+++ b/extensions/gitpod-web/src/extension.ts
@@ -498,6 +498,10 @@ class GitpodPortViewProvider implements vscode.WebviewViewProvider {
 			if (!port) { return; }
 			if (message.command === 'urlCopy' && port.status.exposed) {
 				await vscode.env.clipboard.writeText(port.status.exposed.url);
+				this.context.fireAnalyticsEvent({
+					eventName: 'vscode_execute_command_gitpod_ports',
+					properties: { action: 'urlCopy', isWebview: true, userOverride: String(isUserOverrideSetting('gitpod.experimental.portsView.enabled')) }
+				});
 				return;
 			}
 			vscode.commands.executeCommand('gitpod.ports.' + message.command, { port, isWebview: true });

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -479,6 +479,19 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+configcat-common@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/configcat-common/-/configcat-common-6.0.0.tgz#ccdb9bdafcb6a89144cac17faaab60ac960fed2a"
+  integrity sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA==
+
+configcat-node@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/configcat-node/-/configcat-node-8.0.0.tgz#6a7d2072a848552971d91e2e44c424bfda606d21"
+  integrity sha512-4n4yLMpXWEiB4vmj0HuV3ArgImOEHgT+ZhP+y6N6zdwP1Z4KhQHA3btbDtZbqNw1meaVzhQMjRnpV+k/3Zr8XQ==
+  dependencies:
+    configcat-common "^6.0.0"
+    tunnel "0.0.6"
+
 cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
@@ -1672,6 +1685,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 typescript@4.8.2:
   version "4.8.2"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Description
Improve port event
  - Add copy URL event
  - Add `<a>` click as openBrowser event

Add experiments using ConfigCat with experimental PortsView
  - ConfigCat config.json based on gitpod's configcat proxy
  - ConfigCat [configured](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853) a flag with key `gitpod_experimental_portsView_enabled`
  - Code in `experiments.ts` is a copy of [experiments.ts](https://github.com/gitpod-io/gitpod-vscode-desktop/blob/master/src/experiments.ts)

## How to Test

- Open workspace in prev env https://hw-configcat-vs.preview.gitpod-dev.com/workspaces
- Choose latest code as IDE
- Create a team, and get its team_id (see images below)
- Configure [ConfigCat](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853) gitpod_experimental_portsView_enabled key with team_ids labels appended with your team_id
  - ℹ️ For latest code, we **enabled** portsView by default, so we should set <team_id> as **NOT** enabled in configCat
- See if new PortsView works or not works
- Process in new PortsView, see if events in [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) reported
  - Click on URL link, should open browser and report event
  - Click on copy link icon, should copied to clipboard and report event

|Create|Find Team ID|
|-|-|
|<img width="498" alt="image" src="https://user-images.githubusercontent.com/20944364/189357935-761f944f-e7b7-43cd-92cc-3c3ff7563816.png"> |<img width="1512" alt="image" src="https://user-images.githubusercontent.com/20944364/189358365-31582528-f0ef-49c7-8f22-5f179490f697.png">|
