### PR TITLE
Add UnhandledError telemetry error report

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@gitpod/gitpod-protocol": "main",
-    "@gitpod/ide-metrics-api-grpcweb": "ak-ext-metrics",
+    "@gitpod/ide-metrics-api-grpcweb": "^0.0.1-main.4780",
     "@gitpod/local-app-api-grpcweb": "main",
     "@gitpod/supervisor-api-grpc": "main",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@gitpod/gitpod-protocol": "main",
-    "@gitpod/ide-metrics-api-grpcweb": "ak-ext-metrics",
+    "@gitpod/ide-metrics-api-grpcweb": "^0.0.1-main.4783",
     "@gitpod/supervisor-api-grpc": "main",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@microsoft/1ds-core-js": "^3.2.2",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -3,8 +3,8 @@
 	"version": "0.0.0",
 	"private": true,
 	"dependencies": {
+		"@gitpod/ide-metrics-api-grpcweb": "^0.0.1-main.4783",
 		"@gitpod/local-app-api-grpcweb": "main",
-		"@gitpod/ide-metrics-api-grpcweb": "ak-ext-metrics",
 		"@microsoft/1ds-core-js": "^3.2.2",
 		"@microsoft/1ds-post-js": "^3.2.2",
 		"@vscode/iconv-lite-umd": "0.7.0",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@gitpod/ide-metrics-api-grpcweb@ak-ext-metrics":
-  version "0.0.1-ak-ext-metrics.4"
-  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-ak-ext-metrics.4.tgz#9dacee7f13181e132fba9e4a5b97cb7f4b1739d2"
-  integrity sha512-s1C4W5Q7nlgyaQGCKqG8gI1ZdzwsaFZW2k8VX5hJKIcpD5S60I7AJbP1wVxYhRqR93YW3++DHydSpbjBUVnQFA==
+"@gitpod/ide-metrics-api-grpcweb@^0.0.1-main.4783":
+  version "0.0.1-main.4783"
+  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-main.4783.tgz#d618c0d37713b66eec3a58ae9fc76c91ace222c9"
+  integrity sha512-QxQT/chiDd7qRFUWNhsTHPBi6dgX9n1nuqHpUmqaiXq8KSWHGss4XY2jUfY+V64zmIQmKp/B/M+1H7VWIOQcUg==
   dependencies:
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.19.1"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -36,10 +36,10 @@
     vscode-ws-jsonrpc "^0.2.0"
     ws "^7.4.6"
 
-"@gitpod/ide-metrics-api-grpcweb@ak-ext-metrics":
-  version "0.0.1-ak-ext-metrics.4"
-  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-ak-ext-metrics.4.tgz#9dacee7f13181e132fba9e4a5b97cb7f4b1739d2"
-  integrity sha512-s1C4W5Q7nlgyaQGCKqG8gI1ZdzwsaFZW2k8VX5hJKIcpD5S60I7AJbP1wVxYhRqR93YW3++DHydSpbjBUVnQFA==
+"@gitpod/ide-metrics-api-grpcweb@^0.0.1-main.4783":
+  version "0.0.1-main.4783"
+  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-main.4783.tgz#d618c0d37713b66eec3a58ae9fc76c91ace222c9"
+  integrity sha512-QxQT/chiDd7qRFUWNhsTHPBi6dgX9n1nuqHpUmqaiXq8KSWHGss4XY2jUfY+V64zmIQmKp/B/M+1H7VWIOQcUg==
   dependencies:
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.19.1"

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -168,6 +168,7 @@ export interface IGitpodPreviewConfiguration {
 	log?: {
 		analytics?: boolean;
 		metrics?: boolean;
+		errorReports?: boolean;
 	};
 }
 

--- a/src/vs/gitpod/browser/gitpodInsightsAppender.ts
+++ b/src/vs/gitpod/browser/gitpodInsightsAppender.ts
@@ -1,19 +1,25 @@
-/* eslint-disable code-import-patterns */
+/* eslint-disable local/code-import-patterns */
 /* eslint-disable header/header */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Gitpod. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+/// <reference types='@gitpod/gitpod-protocol/lib/typings/globals'/>
+
 import { IProductService } from 'vs/platform/product/common/productService';
 import { ITelemetryAppender } from 'vs/platform/telemetry/common/telemetryUtils';
-import { mapMetrics, mapTelemetryData } from 'vs/gitpod/common/insightsHelper';
+import { mapMetrics, mapTelemetryData, ReportErrorParam } from 'vs/gitpod/common/insightsHelper';
 import type { IDEMetric } from '@gitpod/ide-metrics-api-grpcweb';
+import type { ErrorEvent } from 'vs/platform/telemetry/common/errorTelemetry';
 
 type SendMetrics = (metrics: IDEMetric[]) => Promise<void>;
+type ErrorReports = (errors: ReportErrorParam) => Promise<void>;
+interface SupervisorWorkspaceInfo { gitpodHost: string; instanceId: string; workspaceId: string }
 
 export class GitpodInsightsAppender implements ITelemetryAppender {
 	private readonly _baseProperties: { appName: string; uiKind: 'web'; version: string };
 	private readonly devMode = this.productService.nameShort.endsWith(' Dev');
+	private gitpodUserId: string | undefined;
 	constructor(
 		@IProductService private readonly productService: IProductService
 	) {
@@ -22,11 +28,19 @@ export class GitpodInsightsAppender implements ITelemetryAppender {
 			uiKind: 'web',
 			version: this.productService.version,
 		};
+		window.gitpod?.service.server.getLoggedInUser().then((user) => {
+			this.gitpodUserId = user.id;
+		}).catch((e) => {
+			console.error('failed to get gitpodUserId', e);
+		});
 	}
 
 	public log(eventName: string, data: any): void {
 		this.sendAnalytics(eventName, data);
 		this.sendMetrics(eventName, data);
+		if (eventName === 'UnhandledError') {
+			this.sendErrorReports(data as ErrorEvent);
+		}
 	}
 
 	private sendAnalytics(eventName: string, data: any): void {
@@ -81,29 +95,87 @@ export class GitpodInsightsAppender implements ITelemetryAppender {
 			return this._sendMetrics;
 		}
 		return this._sendMetrics = (async () => {
-			let gitpodHost: string | undefined;
-			if (!this.devMode) {
-				const infoResponse = await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/info/workspace', {
-					credentials: 'include'
-				});
-				if (!infoResponse.ok) {
-					throw new Error(`Getting workspace info failed: ${infoResponse.statusText}`);
-				}
-				const info: { gitpodHost: string } = await infoResponse.json();
-				gitpodHost = new URL(info.gitpodHost).host;
-			} else if (this.productService.gitpodPreview) {
-				gitpodHost = this.productService.gitpodPreview.host;
-			}
-			if (!gitpodHost) {
+			const gitpodWsInfo = await this.getGitpodWorkspaceInfo();
+			if (!gitpodWsInfo.gitpodHost) {
 				return undefined;
 			}
 			// load grpc-web before see https://github.com/gitpod-io/gitpod/issues/4448
 			await import('@improbable-eng/grpc-web');
 			const { MetricsServiceClient, sendMetrics } = await import('@gitpod/ide-metrics-api-grpcweb');
-			const ideMetricsEndpoint = 'https://ide.' + gitpodHost + '/metrics-api';
+			const ideMetricsEndpoint = 'https://ide.' + gitpodWsInfo.gitpodHost + '/metrics-api';
 			const client = new MetricsServiceClient(ideMetricsEndpoint);
 			return async (metrics: IDEMetric[]) => {
 				await sendMetrics(client, metrics);
+			};
+		})();
+	}
+
+	private async sendErrorReports(error: ErrorEvent) {
+		const gitpodWsInfo = await this.getGitpodWorkspaceInfo();
+		const params: ReportErrorParam = {
+			workspaceId: gitpodWsInfo.workspaceId,
+			instanceId: gitpodWsInfo.instanceId,
+			errorStack: error.callstack,
+			userId: this.gitpodUserId ?? '',
+			component: 'vscode-web',
+			version: this._baseProperties.version,
+			properties: {
+				error_name: error.uncaught_error_name,
+				error_message: error.msg,
+				...this._baseProperties,
+			}
+		};
+		if (this.devMode && this.productService.gitpodPreview?.log?.errorReports) {
+			console.log('Gitpod Error Reports: ', JSON.stringify(params, undefined, 2));
+		}
+		const doSend = await this.getSendErrorReports();
+		if (doSend) {
+			await doSend(params);
+		}
+	}
+
+	private _sendErrorReports: Promise<ErrorReports | undefined> | undefined;
+	private getSendErrorReports(): Promise<ErrorReports | undefined> {
+		if (this._sendErrorReports) {
+			return this._sendErrorReports;
+		}
+		return this._sendErrorReports = (async () => {
+			const gitpodWsInfo = await this.getGitpodWorkspaceInfo();
+			if (!gitpodWsInfo.gitpodHost) {
+				return undefined;
+			}
+			const ideMetricsHttpEndpoint = 'https://ide.' + gitpodWsInfo.gitpodHost + '/metrics-api/reportError';
+			return async (params: ReportErrorParam) => {
+				const response = await fetch(ideMetricsHttpEndpoint, {
+					method: 'POST',
+					body: JSON.stringify(params),
+					credentials: 'omit',
+				});
+				if (!response.ok) {
+					const data = await response.json();
+					console.error(`Cannot report error: ${response.status} ${response.statusText}`, data);
+				}
+			};
+		})();
+	}
+
+	private _gitpodWsInfo: Promise<SupervisorWorkspaceInfo> | undefined;
+	private getGitpodWorkspaceInfo(): Promise<SupervisorWorkspaceInfo> {
+		if (this._gitpodWsInfo) {
+			return this._gitpodWsInfo;
+		}
+		return this._gitpodWsInfo = (async () => {
+			const infoResponse = await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/info/workspace', {
+				credentials: 'include'
+			});
+			if (!infoResponse.ok) {
+				throw new Error(`Getting workspace info failed: ${infoResponse.statusText}`);
+			}
+			const info: SupervisorWorkspaceInfo = await infoResponse.json();
+			return {
+				gitpodHost: this.devMode ? this.productService.gitpodPreview?.host ?? 'gitpod-staging.com' : new URL(info.gitpodHost).host,
+				instanceId: info.instanceId,
+				workspaceId: info.workspaceId
 			};
 		})();
 	}

--- a/src/vs/gitpod/common/insightsHelper.ts
+++ b/src/vs/gitpod/common/insightsHelper.ts
@@ -1,4 +1,4 @@
-/* eslint-disable code-import-patterns */
+/* eslint-disable local/code-import-patterns */
 /* eslint-disable header/header */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Gitpod. All rights reserved.
@@ -6,7 +6,21 @@
 
 import { RemoteTrackMessage } from '@gitpod/gitpod-protocol/lib/analytics';
 import type { IDEMetric } from '@gitpod/ide-metrics-api-grpcweb/lib/index';
+import type { ErrorEvent } from 'vs/platform/telemetry/common/errorTelemetry';
 
+export interface GitpodErrorEvent extends ErrorEvent {
+	fromBrowser?: boolean;
+}
+
+export interface ReportErrorParam {
+	workspaceId: string;
+	instanceId: string;
+	errorStack: string;
+	userId: string;
+	component: string;
+	version: string;
+	properties?: Record<string, any>;
+}
 
 function getEventName(name: string) {
 	const str = name.replace('remoteConnection', '').replace('remoteReconnection', '');
@@ -23,17 +37,11 @@ function getEventName(name: string) {
 let readAccessTracked = false;
 let writeAccessTracked = false;
 
-export enum SenderKind {
-	Browser = 1,
-	Node = 2
-}
-
-// TODO map 'UnhandledError' to our error and report it both only for window and remote-server
-
 export function mapMetrics(source: 'window' | 'remote-server', eventName: string, data: any): IDEMetric[] | undefined {
 	const maybeMetrics = doMapMetrics(source, eventName, data);
 	return maybeMetrics instanceof Array ? maybeMetrics : typeof maybeMetrics === 'object' ? [maybeMetrics] : undefined;
 }
+
 function doMapMetrics(source: 'window' | 'remote-server', eventName: string, data: any): IDEMetric[] | IDEMetric | undefined {
 	if (source === 'remote-server') {
 		if (eventName.startsWith('extensionGallery:')) {

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -203,7 +203,7 @@ export class TelemetryService implements ITelemetryService {
 			{ label: 'Google API Key', regex: /AIza[A-Za-z0-9_\\\-]{35}/ },
 			{ label: 'Slack Token', regex: /xox[pbar]\-[A-Za-z0-9]/ },
 			{ label: 'Generic Secret', regex: /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/ },
-			{ label: 'Email', regex: /@[a-zA-Z0-9-.]+/ } // Regex which matches @*.site
+			{ label: 'Email', regex: /@[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+/ } // Regex which matches *@*.site
 		];
 
 		// Check for common user data in the telemetry events

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -19,8 +19,11 @@ import { getTelemetryLevel, isInternalTelemetry, ITelemetryAppender, NullTelemet
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { resolveWorkbenchCommonProperties } from 'vs/workbench/services/telemetry/browser/workbenchCommonProperties';
-// eslint-disable-next-line code-import-patterns
+// eslint-disable-next-line local/code-import-patterns
 import { GitpodInsightsAppender } from 'vs/gitpod/browser/gitpodInsightsAppender';
+import { ErrorEvent } from 'vs/platform/telemetry/common/errorTelemetry';
+// eslint-disable-next-line local/code-import-patterns
+import { GitpodErrorEvent } from 'vs/gitpod/common/insightsHelper';
 
 export class TelemetryService extends Disposable implements ITelemetryService {
 
@@ -100,6 +103,13 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 	}
 
 	publicLogError(errorEventName: string, data?: ITelemetryData): Promise<void> {
+		if (errorEventName === 'UnhandledError') {
+			const errData: GitpodErrorEvent = {
+				...(data as ErrorEvent),
+				fromBrowser: true,
+			};
+			return this.impl.publicLog(errorEventName, errData);
+		}
 		return this.impl.publicLog(errorEventName, data);
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,10 @@
     vscode-ws-jsonrpc "^0.2.0"
     ws "^7.4.6"
 
-"@gitpod/ide-metrics-api-grpcweb@ak-ext-metrics":
-  version "0.0.1-ak-ext-metrics.4"
-  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-ak-ext-metrics.4.tgz#9dacee7f13181e132fba9e4a5b97cb7f4b1739d2"
-  integrity sha512-s1C4W5Q7nlgyaQGCKqG8gI1ZdzwsaFZW2k8VX5hJKIcpD5S60I7AJbP1wVxYhRqR93YW3++DHydSpbjBUVnQFA==
+"@gitpod/ide-metrics-api-grpcweb@^0.0.1-main.4780":
+  version "0.0.1-main.4780"
+  resolved "https://registry.yarnpkg.com/@gitpod/ide-metrics-api-grpcweb/-/ide-metrics-api-grpcweb-0.0.1-main.4780.tgz#2131c4d0634f243c58cc1958d403b640ee08d727"
+  integrity sha512-OknhowSlzKT6a+PWwdZ/Ot7gOgp60EkIT4yoyQ/0GUJSlEy+d8gDwZObLGMY/KzJC4Qrv8FN4/vLMYShh0jTpA==
   dependencies:
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.19.1"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Add UnhandledError telemetry error report

## How to Test

Use latest code and open workspace in preview env https://hw-vserror-report.preview.gitpod-dev.com/workspaces

### Browser Error Catch

- Toggle browser DevTool Console, exec code below
```
async function willThrow(str) {
    throw new Error(str);
}
willThrow('<anything_you_want>')
```
- Go to [GCP error report](https://console.cloud.google.com/errors?referrer=search&project=gitpod-core-dev) search with what you has throwed. It should be here with service named `vscode-web`. Access log detail,`userId` `workspaceId` `instanceId` should exists
- GCP error report should have only one message that you just sent, without service `vscode-server` since we filter them

### Server Error Catch

TODO...

Need to add debug commit for it, but we can manually get an error by changing browser resources code, to make `fromBrowser` always `false` to make browser telemetry duplicate in server