### PR TITLE
Remove usage of `.public`

### DIFF
--- a/extensions/gitpod-shared/src/workspacePort.ts
+++ b/extensions/gitpod-shared/src/workspacePort.ts
@@ -115,8 +115,7 @@ export class GitpodWorkspacePort {
 
 		const accessible = exposed || tunnel;
 
-		// We use .public here because https://github.com/gitpod-io/openvscode-server/pull/360#discussion_r882953586
-		const isPortTunnelPublic = !!tunnel?.public;
+		const isPortTunnelPublic = tunnel?.privacy === 'public';
 		if (!served) {
 			port.description = 'not served';
 			port.iconStatus = 'NotServed';

--- a/extensions/gitpod-web/src/extension.ts
+++ b/extensions/gitpod-web/src/extension.ts
@@ -501,7 +501,7 @@ async function registerPorts(context: GitpodExtensionContext): Promise<void> {
 		const request = new TunnelPortRequest();
 		request.setPort(tunnelOptions.remoteAddress.port);
 		request.setTargetPort(tunnelOptions.localAddressPort || tunnelOptions.remoteAddress.port);
-		request.setVisibility(!!tunnelOptions?.public ? TunnelVisiblity.NETWORK : TunnelVisiblity.HOST);
+		request.setVisibility(tunnelOptions.privacy === 'public' ? TunnelVisiblity.NETWORK : TunnelVisiblity.HOST);
 		await util.promisify(context.supervisor.port.tunnel.bind(context.supervisor.port, request, context.supervisor.metadata, {
 			deadline: Date.now() + context.supervisor.deadlines.normal
 		}))();


### PR DESCRIPTION
Adhere to changes made in https://github.com/microsoft/vscode/commit/d56f8a8ddee825a784b8964cae91ce6e60b6b844

## How to test

1. Open a repository with ports config in the preview environment: https://ft-test-ports-public.preview.gitpod-dev.com/workspaces
2. play around with ports' visibility. Make sure toggling and displaying correctly reflects the port's public/private state.