### PR TITLE
Add `.gitpod.yml` url extension validate

### DIFF
--- a/extensions/gitpod-web/src/util/download.ts
+++ b/extensions/gitpod-web/src/util/download.ts
@@ -42,6 +42,8 @@ export function download(url: string, dest: string, token: vscode.CancellationTo
 			} else {
 				reject(new Error(`Download request failed, response status: ${res.statusCode} ${res.statusMessage}`));
 			}
+		}).on('error', (err) => {
+			reject(err);
 		});
 
 		if (timeout) {


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/gitpod-io/gitpod/issues/5466

## How to Test
- Open Gitpod with current PR
- Open browser for port `9888`
- Change `.gitpod.yml` vscode extension to something like below
- Check validator and quickfix
- ❓ How to find `isMachineScoped` extensions?

```
vscode:
  extensions:
    - dbaeumer.vscode-eslint
    - svelte.svelte-vscode
    - svelte.svelte-vscode-not-found12
    - https://openvsxorg.blob.core.windows.net/resources/redhat/java/linux-x64/1.13.2022112403/redhat.java-1.13.2022112403@linux-x64.vsix
    - https://openvsxorg.blob.core
    - https://openvsxorg.blob.core.windows.net/resources/timonwong/shellcheck/linux-x64/0.28.2/timonwong.shellcheck-0.28.2@linux-x64.vsix
```

## Screenshot

URL not Installed
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/20944364/204393364-51ff1183-e8c9-49b3-9df1-874aa6baef2f.png">

URL is not .vsix File
<img width="814" alt="image" src="https://user-images.githubusercontent.com/20944364/204397460-8f51a4e9-ac63-4555-b960-85619f558b9b.png">

Quick Fix
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/20944364/204397835-08e7317f-a3cb-4119-b3e2-0671792d5faf.png">

