### PR TITLE
 Add option to disable release notes completely 

### DIFF
--- a/extensions/gitpod-web/package.json
+++ b/extensions/gitpod-web/package.json
@@ -507,6 +507,12 @@
           "type": "boolean",
           "description": "Control whether to prompt to open in VS Code Desktop on page load.",
           "default": false
+        },
+        "gitpod.showReleaseNotes": {
+          "type": "boolean",
+          "description": "Show the Gitpod Changelog whenever a new one comes out.",
+          "default": true,
+          "scope": "application"
         }
       }
     },

--- a/extensions/gitpod-web/src/releaseNotes.ts
+++ b/extensions/gitpod-web/src/releaseNotes.ts
@@ -71,6 +71,9 @@ export class ReleaseNotes extends Disposable {
 				ttl: this.getResponseCacheTime(resp),
 			};
 		});
+		if (!md) {
+			return;
+		}
 
 		const parseInfo = (md: string) => {
 			if (!md.startsWith('---')) {
@@ -113,7 +116,15 @@ export class ReleaseNotes extends Disposable {
 		}
 
 		const releaseId = await this.getLastPublish();
+		if (!releaseId) {
+			return;
+		}
+
 		const mdContent = await this.loadChangelog(releaseId);
+		if (!mdContent) {
+			return;
+		}
+
 		const html = await vscode.commands.executeCommand<string>('markdown.api.render', mdContent);
 		this.panel.webview.html = `<!DOCTYPE html>
 <html lang="en">
@@ -143,10 +154,13 @@ export class ReleaseNotes extends Disposable {
 	}
 
 	private async showIfNewRelease(lastReadId: string | undefined) {
-		const releaseId = await this.getLastPublish();
-		console.log(`gitpod release notes lastReadId: ${lastReadId}, latestReleaseId: ${releaseId}`);
-		if (releaseId !== lastReadId) {
-			this.createOrShow();
+		const showReleaseNotes = vscode.workspace.getConfiguration('gitpod').get<boolean>('showReleaseNotes');
+		if (showReleaseNotes) {
+			const releaseId = await this.getLastPublish();
+			if (releaseId && releaseId !== lastReadId) {
+				console.log(`gitpod release notes lastReadId: ${lastReadId}, latestReleaseId: ${releaseId}`);
+				this.createOrShow();
+			}
 		}
 	}
 

--- a/extensions/gitpod-web/src/util/cache.ts
+++ b/extensions/gitpod-web/src/util/cache.ts
@@ -40,12 +40,15 @@ export class CacheHelper {
 		return now > data.expiration ? undefined : data.value;
 	}
 
-	async getOrRefresh<T>(key: string, refreshCallback: () => Thenable<{ value: T; ttl?: number }>): Promise<T> {
+	async getOrRefresh<T>(key: string, refreshCallback: () => Thenable<{ value: T; ttl?: number }>): Promise<T | undefined> {
 		let value = this.get<T>(key);
 		if (value === undefined) {
-			const result = await refreshCallback();
-			await this.set(key, result.value, result.ttl);
-			value = result.value;
+			try {
+				const result = await refreshCallback();
+				await this.set(key, result.value, result.ttl);
+				value = result.value;
+			} catch {
+			}
 		}
 		return value;
 	}


### PR DESCRIPTION
In Gitpod Web, make it possible to disable showing the release notes ever.

A sister PR to https://github.com/gitpod-io/gitpod-vscode-desktop/pull/29.