### PR TITLE
Add command to `run-gp` with Codelens

### DIFF
--- a/extensions/gitpod-remote/package.json
+++ b/extensions/gitpod-remote/package.json
@@ -151,7 +151,12 @@
       {
         "command": "gitpod.gitpodyml.build",
         "title": "%buildGitpodYml%",
-        "icon": "$(run)"
+        "icon": "$(tools)"
+      },
+      {
+        "command": "gitpod.gitpodyml.run",
+        "title": "%runGitpodYml%",
+        "icon": "$(play)"
       }
     ],
     "menus": {
@@ -237,11 +242,21 @@
           "command": "gitpod.gitpodyml.build",
           "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
           "group": "0_navigation@0"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
+          "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
+          "group": "0_navigation@0"
         }
       ],
       "editor/title":[
         {
           "command": "gitpod.gitpodyml.build",
+          "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
+          "group": "navigation"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
           "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
           "group": "navigation"
         }
@@ -277,6 +292,10 @@
         },
         {
           "command": "gitpod.gitpodyml.build",
+          "when": "gitpod.run-gp.enabled"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
           "when": "gitpod.run-gp.enabled"
         }
       ]

--- a/extensions/gitpod-remote/package.nls.json
+++ b/extensions/gitpod-remote/package.nls.json
@@ -25,5 +25,6 @@
 	"tunnelHost": "Tunnel on localhost",
 	"retryAutoExpose": "Retry to expose",
 	"openWebLinkInBrowser": "Open web link in Browser",
-	"buildGitpodYml": "Build container image"
+	"buildGitpodYml": "Gitpod: Build Gitpod Configuration",
+	"runGitpodYml": "Gitpod: Test Gitpod Configuration"
 }

--- a/extensions/gitpod-web/package.json
+++ b/extensions/gitpod-web/package.json
@@ -172,7 +172,12 @@
       {
         "command": "gitpod.gitpodyml.build",
         "title": "%buildGitpodYml%",
-        "icon": "$(run)"
+        "icon": "$(tools)"
+      },
+      {
+        "command": "gitpod.gitpodyml.run",
+        "title": "%runGitpodYml%",
+        "icon": "$(play)"
       }
     ],
     "menus": {
@@ -335,6 +340,10 @@
         {
           "command": "gitpod.gitpodyml.build",
           "when": "gitpod.run-gp.enabled"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
+          "when": "gitpod.run-gp.enabled"
         }
       ],
       "statusBar/remoteIndicator": [
@@ -429,11 +438,21 @@
           "command": "gitpod.gitpodyml.build",
           "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
           "group": "0_navigation@0"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
+          "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
+          "group": "0_navigation@0"
         }
       ],
       "editor/title":[
         {
           "command": "gitpod.gitpodyml.build",
+          "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
+          "group": "navigation"
+        },
+        {
+          "command": "gitpod.gitpodyml.run",
           "when": "gitpod.run-gp.enabled && resourceFilename == '.gitpod.yml' && resourceScheme == file",
           "group": "navigation"
         }

--- a/extensions/gitpod-web/package.nls.json
+++ b/extensions/gitpod-web/package.nls.json
@@ -29,5 +29,6 @@
 	"openInStable": "Gitpod: Open in VS Code",
 	"openInInsiders": "Gitpod: Open in VS Code Insiders",
 	"openInBrowser": "Gitpod: Open in Browser",
-	"buildGitpodYml": "Build container image"
+	"buildGitpodYml": "Gitpod: Build Gitpod Configuration",
+	"runGitpodYml": "Gitpod: Test Gitpod Configuration"
 }


### PR DESCRIPTION
Make a new command available in the Codelens pallete and other places in the editor when working on your `.gitpod.yml` – along with the build command a new run command, which will run tasks as well.