### PR TITLE
Disable `Git: Continue Working in New Local Clone`

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -57,7 +57,7 @@
         "title": "%command.continueInLocalClone%",
         "category": "Git",
         "icon": "$(repo-clone)",
-        "enablement": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName"
+        "enablement": "false && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName"
       },
       {
         "command": "git.clone",
@@ -725,7 +725,7 @@
       {
         "command": "git.continueInLocalClone",
         "qualifiedName": "%command.continueInLocalClone.qualifiedName%",
-        "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName",
+        "when": "false && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName",
         "remoteGroup": "remote_42_git_0_local@0"
       }
     ],


### PR DESCRIPTION
Makes it so that for our distributions the <kbd>Git: Continue Working in New Local Clone</kbd> command is never accessible from the UI. 

> **Note**: we should cherry-pick this to `main` afterwards as well