### PR TITLE
Spread `originalConfig` rather than reconstructing it

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -400,12 +400,8 @@ class WorkspaceProvider implements IWorkspaceProvider {
 	}
 	const originalConfig: IWorkbenchConstructionOptions & { folderUri?: UriComponents; workspaceUri?: UriComponents; callbackRoute: string } = JSON.parse(configElementAttribute);
 	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents; workspaceUri?: UriComponents; callbackRoute: string } = {
+		...originalConfig,
 		remoteAuthority: window.location.host,
-		developmentOptions: originalConfig.developmentOptions,
-		settingsSyncOptions: originalConfig.settingsSyncOptions,
-		folderUri: originalConfig.folderUri,
-		workspaceUri: originalConfig.workspaceUri,
-		callbackRoute: originalConfig.callbackRoute
 	};
 
 	// Create workbench
@@ -413,7 +409,6 @@ class WorkspaceProvider implements IWorkspaceProvider {
 		...config,
 		windowIndicator: config.windowIndicator ?? { label: '$(remote)', tooltip: `${product.nameShort} Web` },
 		settingsSyncOptions: config.settingsSyncOptions ? { enabled: config.settingsSyncOptions.enabled, } : undefined,
-		developmentOptions: { ...config.developmentOptions },
 		workspaceProvider: WorkspaceProvider.create(config),
 		urlCallbackProvider: new LocalStorageURLCallbackProvider(config.callbackRoute),
 		secretStorageProvider: config.remoteAuthority ? undefined /* with a remote, we don't use a local secret storage provider */ : new LocalStorageSecretStorageProvider()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Instead of reconstructing a whole new object, spread the original one in and only override the one item that's important aka `remoteAuthority`.

This avoids a problem where certain construction options [set by the server](https://github.com/gitpod-io/openvscode-server/blob/45844b4126db1a09e90ac17dad865133917162fa/src/vs/server/node/webClientServer.ts#L327-L337) (like `enableWorkspaceTrust`) would be lost.
